### PR TITLE
Update ArrayAccess method return types for PHP 8.1 compatibility

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -330,7 +330,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return !is_null($this->getAttribute($offset));
     }
@@ -342,7 +342,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->getAttribute($offset);
     }
@@ -355,7 +355,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->setAttribute($offset, $value);
     }
@@ -367,7 +367,7 @@ abstract class Model implements ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->attributes[$offset]);
     }


### PR DESCRIPTION
This PR updates the return types of `ArrayAccess` interface methods in order to suppress [deprecation notices](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.type-compatibility-internal) when using the package with PHP 8.1.