### PR TITLE
Set cache on findOne method

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -111,7 +111,10 @@ class Api
             return $this->getCache($key);
         }
 
-        return $this->getTransport()->request($uri, $filters) ?? [];
+        return $this->setCache(
+            $key,
+            $this->getTransport()->request($uri, $filters) ?? []
+        );
     }
 
     /**


### PR DESCRIPTION
Per the observation [here](https://github.com/CristalTeam/php-api-wrapper/issues/28), I've updated the `findOne` method in `Cristal\ApiWrapper\Api` to utilize the cache.